### PR TITLE
Fix/disable out of stock options

### DIFF
--- a/src/Tags/ProductVariants.php
+++ b/src/Tags/ProductVariants.php
@@ -130,7 +130,7 @@ class ProductVariants extends Tags
                 $title .= ' (' . config('shopify.lang.out_of_stock') . ')';
             }
 
-            $html .= '<option value="' . $variant['storefront_id'] . '" data-in-stock="' . $out_of_stock . '" ' . $disabled . '>' . $title . '</option>';
+            $html .= '<option value="' . $variant['storefront_id'] . '" ' . $disabled . '>' . $title . '</option>';
         }
 
         return $html;

--- a/src/Tags/ProductVariants.php
+++ b/src/Tags/ProductVariants.php
@@ -113,10 +113,12 @@ class ProductVariants extends Tags
         foreach ($variants as $variant) {
             $title = $variant['title'];
             $out_of_stock = false;
+            $disabled = '';
 
             if (isset($variant['inventory_policy'])) {
                 if ($variant['inventory_policy'] === 'deny' && $variant['inventory_quantity'] === 0) {
                     $out_of_stock = true;
+                    $disabled = 'disabled';
                 }
             }
 
@@ -128,7 +130,7 @@ class ProductVariants extends Tags
                 $title .= ' (' . config('shopify.lang.out_of_stock') . ')';
             }
 
-            $html .= '<option value="' . $variant['storefront_id'] . '" data-in-stock="' . $out_of_stock . '">' . $title . '</option>';
+            $html .= '<option value="' . $variant['storefront_id'] . '" data-in-stock="' . $out_of_stock . '" ' . $disabled . '>' . $title . '</option>';
         }
 
         return $html;


### PR DESCRIPTION
Hi!

**Disabled state**

I've added the disabled state to the options that don't allow buying. (configured as deny in shopify). 

Right now you can add them to your cart and it will fail at checkout. (You'll get a message that the item is unavailable and be forced to remove it, which is an unnecessary step).

I think the correct approach is to simply disable these options. Feel free to refactor my code if needed.

**data-in-stock**

I removed data-in-stock. I can't see anywhere this is used... but feel free to reverse that commit if I misssed something.

**show_out_of_stock**

Finally, my initial understanding of the show_out_of_stock="true" param was that it would show or hide the options themselves. I see this is only to show or hide the _label_. Maybe it should be show_out_of_stock_label ? (I haven't touched this as this involves the docs as well)

Also, perhaps hiding out of stock options would indeed be useful? But I guess you can remove them in Shopify to achieve the same thing, and probably remove the images for options that aren't there.